### PR TITLE
Update pynvml.smi to use the new location

### DIFF
--- a/voir/instruments/gpu/cuda.py
+++ b/voir/instruments/gpu/cuda.py
@@ -9,7 +9,7 @@ try:
         NVMLError_DriverNotLoaded,
         NVMLError_LibraryNotFound,
     )
-    from pynvml.smi import nvidia_smi
+    from pynvml_utils import nvidia_smi
 except ImportError as err:
     IMPORT_ERROR = err
 


### PR DESCRIPTION
```
/home/mila/d/delaunap/conda/envs/py310/lib/python3.10/site-packages/pynvml/smi.py:5: FutureWarning: The pynvml.smi module is deprecated and will be removed in the next release of pynvml. Please use pynvml_utils:
(e.g. `from pynvml_utils import nvidia_smi`)
  warnings.warn(
```