### PR TITLE
Add driver version to gpu info

### DIFF
--- a/voir/instruments/gpu/cuda.py
+++ b/voir/instruments/gpu/cuda.py
@@ -1,5 +1,5 @@
-import shlex
 import os
+import shlex
 import subprocess
 import traceback
 

--- a/voir/instruments/gpu/cuda.py
+++ b/voir/instruments/gpu/cuda.py
@@ -1,6 +1,4 @@
 import os
-import shlex
-import subprocess
 import traceback
 
 from .common import NotAvailable
@@ -71,11 +69,7 @@ def make_gpu_info(gid, handle, selection):
         ),
         "power": fix_num(safecall(pynvml.nvmlDeviceGetPowerUsage, handle)) / 1000.0,
         "selection_variable": "CUDA_VISIBLE_DEVICES",
-        "driver": subprocess.run(
-            shlex.split("modinfo nvidia --field version"),
-            capture_output=True,
-            encoding="utf8",
-        ).stdout.strip(),
+        "driver": pynvml.nvmlSystemGetDriverVersion(),
     }
 
 

--- a/voir/instruments/gpu/cuda.py
+++ b/voir/instruments/gpu/cuda.py
@@ -1,4 +1,6 @@
+import shlex
 import os
+import subprocess
 import traceback
 
 from .common import NotAvailable
@@ -69,6 +71,11 @@ def make_gpu_info(gid, handle, selection):
         ),
         "power": fix_num(safecall(pynvml.nvmlDeviceGetPowerUsage, handle)) / 1000.0,
         "selection_variable": "CUDA_VISIBLE_DEVICES",
+        "driver": subprocess.run(
+            shlex.split("modinfo nvidia --field version"),
+            capture_output=True,
+            encoding="utf8"
+        ).stdout.strip(),
     }
 
 

--- a/voir/instruments/gpu/cuda.py
+++ b/voir/instruments/gpu/cuda.py
@@ -74,7 +74,7 @@ def make_gpu_info(gid, handle, selection):
         "driver": subprocess.run(
             shlex.split("modinfo nvidia --field version"),
             capture_output=True,
-            encoding="utf8"
+            encoding="utf8",
         ).stdout.strip(),
     }
 

--- a/voir/instruments/gpu/hpu.py
+++ b/voir/instruments/gpu/hpu.py
@@ -1,6 +1,4 @@
 import os
-import shlex
-import subprocess
 import traceback
 
 from .common import NotAvailable
@@ -103,11 +101,7 @@ def make_gpu_info(gid, handle, selection):
         ),
         "power": fix_num(safecall(pyhlml.hlmlDeviceGetPowerUsage, handle)) / 1000.0,
         "selection_variable": "HABANA_VISIBLE_MODULES",
-        "driver": subprocess.run(
-            shlex.split("modinfo gaudi --field version"),
-            capture_output=True,
-            encoding="utf8",
-        ).stdout.strip(),
+        "driver": pyhlml.hlmlGetDriverVersion(),
     }
 
 

--- a/voir/instruments/gpu/hpu.py
+++ b/voir/instruments/gpu/hpu.py
@@ -1,5 +1,5 @@
-import shlex
 import os
+import shlex
 import subprocess
 import traceback
 

--- a/voir/instruments/gpu/hpu.py
+++ b/voir/instruments/gpu/hpu.py
@@ -1,4 +1,6 @@
+import shlex
 import os
+import subprocess
 import traceback
 
 from .common import NotAvailable
@@ -101,6 +103,11 @@ def make_gpu_info(gid, handle, selection):
         ),
         "power": fix_num(safecall(pyhlml.hlmlDeviceGetPowerUsage, handle)) / 1000.0,
         "selection_variable": "HABANA_VISIBLE_MODULES",
+        "driver": subprocess.run(
+            shlex.split("modinfo gaudi --field version"),
+            capture_output=True,
+            encoding="utf8"
+        ).stdout.strip(),
     }
 
 

--- a/voir/instruments/gpu/hpu.py
+++ b/voir/instruments/gpu/hpu.py
@@ -106,7 +106,7 @@ def make_gpu_info(gid, handle, selection):
         "driver": subprocess.run(
             shlex.split("modinfo gaudi --field version"),
             capture_output=True,
-            encoding="utf8"
+            encoding="utf8",
         ).stdout.strip(),
     }
 

--- a/voir/instruments/gpu/rocm.py
+++ b/voir/instruments/gpu/rocm.py
@@ -1,6 +1,4 @@
 import os
-import shlex
-import subprocess
 
 from .common import NotAvailable
 
@@ -207,11 +205,7 @@ class DeviceSMI:
             "temperature": temp,
             "power": power,
             "selection_variable": "ROCR_VISIBLE_DEVICES",
-            "driver": subprocess.run(
-                shlex.split("modinfo rocm --field version"),
-                capture_output=True,
-                encoding="utf8",
-            ).stdout.strip(),
+            "driver": rsmi.smi_get_kernel_version(),
         }
 
     @property

--- a/voir/instruments/gpu/rocm.py
+++ b/voir/instruments/gpu/rocm.py
@@ -1,4 +1,6 @@
+import shlex
 import os
+import subprocess
 
 from .common import NotAvailable
 
@@ -205,6 +207,11 @@ class DeviceSMI:
             "temperature": temp,
             "power": power,
             "selection_variable": "ROCR_VISIBLE_DEVICES",
+            "driver": subprocess.run(
+                shlex.split("modinfo rocm --field version"),
+                capture_output=True,
+                encoding="utf8"
+            ).stdout.strip(),
         }
 
     @property

--- a/voir/instruments/gpu/rocm.py
+++ b/voir/instruments/gpu/rocm.py
@@ -210,7 +210,7 @@ class DeviceSMI:
             "driver": subprocess.run(
                 shlex.split("modinfo rocm --field version"),
                 capture_output=True,
-                encoding="utf8"
+                encoding="utf8",
             ).stdout.strip(),
         }
 

--- a/voir/instruments/gpu/rocm.py
+++ b/voir/instruments/gpu/rocm.py
@@ -1,5 +1,5 @@
-import shlex
 import os
+import shlex
 import subprocess
 
 from .common import NotAvailable

--- a/voir/instruments/gpu/xpu.py
+++ b/voir/instruments/gpu/xpu.py
@@ -1,5 +1,4 @@
 import os
-import shlex
 import subprocess
 
 from .common import NotAvailable
@@ -84,11 +83,8 @@ def query_gpu_data(gpu):
                 "temperature": parse(temp, float, 0),
                 "power": parse(power, float, 0),
                 "selection_variable": "ONEAPI_DEVICE_SELECTOR",
-                "driver": subprocess.run(
-                    shlex.split("modinfo xpu --field version"),
-                    capture_output=True,
-                    encoding="utf8",
-                ).stdout.strip(),
+                # What would got here?
+                "driver": "",
             }
         )
     return data

--- a/voir/instruments/gpu/xpu.py
+++ b/voir/instruments/gpu/xpu.py
@@ -1,3 +1,4 @@
+import shlex
 import os
 import subprocess
 
@@ -83,6 +84,11 @@ def query_gpu_data(gpu):
                 "temperature": parse(temp, float, 0),
                 "power": parse(power, float, 0),
                 "selection_variable": "ONEAPI_DEVICE_SELECTOR",
+                "driver": subprocess.run(
+                    shlex.split("modinfo xpu --field version"),
+                    capture_output=True,
+                    encoding="utf8"
+                ).stdout.strip(),
             }
         )
     return data

--- a/voir/instruments/gpu/xpu.py
+++ b/voir/instruments/gpu/xpu.py
@@ -87,7 +87,7 @@ def query_gpu_data(gpu):
                 "driver": subprocess.run(
                     shlex.split("modinfo xpu --field version"),
                     capture_output=True,
-                    encoding="utf8"
+                    encoding="utf8",
                 ).stdout.strip(),
             }
         )

--- a/voir/instruments/gpu/xpu.py
+++ b/voir/instruments/gpu/xpu.py
@@ -1,5 +1,5 @@
-import shlex
 import os
+import shlex
 import subprocess
 
 from .common import NotAvailable


### PR DESCRIPTION
Add driver version to gpu info.

This is to at least keep a trace of the driver version across executions of milabench