### PR TITLE
Handle multi byte utf8 characters

### DIFF
--- a/src/voir/smuggle.py
+++ b/src/voir/smuggle.py
@@ -123,7 +123,6 @@ class Decoder:
         self.data = LineAccumulator()
         self.code = ""
         self.coding = False
-        self.utf8_decoder = utf8_decoder()
 
     def close(self):
         self.principal.close()
@@ -182,7 +181,7 @@ class Decoder:
                 nxt += self.principal.read(1)
 
             self.process_char(nxt.decode("utf8"))
-        
+
         return result
 
 

--- a/src/voir/smuggle.py
+++ b/src/voir/smuggle.py
@@ -88,6 +88,10 @@ class LineAccumulator:
             self.lines.append(self.current)
             self.current = ""
 
+def utf8_decoder():
+    import codecs
+    return codecs.getincrementaldecoder("utf-8")()
+
 
 class Decoder:
     """Decoder for a stream where data has been smuggled.
@@ -108,6 +112,7 @@ class Decoder:
         self.data = LineAccumulator()
         self.code = ""
         self.coding = False
+        self.utf8_decoder = utf8_decoder()
 
     def close(self):
         self.principal.close()
@@ -160,8 +165,14 @@ class Decoder:
         while (result := self.getline(which)) is None:
             nxt = self.principal.read(1)
             if not nxt:
+                remaining = self.utf8_decoder.decode(b"", final=True)
+                for char in remaining:
+                    self.process_char(char)
                 return None
-            self.process_char(nxt.decode("utf8"))
+
+            for char in self.utf8_decoder.decode(nxt, final=False):
+                self.process_char(char)
+        
         return result
 
 

--- a/src/voir/smuggle.py
+++ b/src/voir/smuggle.py
@@ -88,9 +88,20 @@ class LineAccumulator:
             self.lines.append(self.current)
             self.current = ""
 
-def utf8_decoder():
-    import codecs
-    return codecs.getincrementaldecoder("utf-8")()
+
+def utf8_length(char: chr) -> int:
+    """Return number of bytes a UTF-8 character uses from its first byte."""
+    b = ord(char)
+
+    if b & 0b10000000 == 0:
+        return 1  # ASCII
+    elif b & 0b11100000 == 0b11000000:
+        return 2
+    elif b & 0b11110000 == 0b11100000:
+        return 3
+    elif b & 0b11111000 == 0b11110000:
+        return 4
+    return 1
 
 
 class Decoder:
@@ -165,13 +176,12 @@ class Decoder:
         while (result := self.getline(which)) is None:
             nxt = self.principal.read(1)
             if not nxt:
-                remaining = self.utf8_decoder.decode(b"", final=True)
-                for char in remaining:
-                    self.process_char(char)
                 return None
 
-            for char in self.utf8_decoder.decode(nxt, final=False):
-                self.process_char(char)
+            for i in range(utf8_length(nxt) - 1):
+                nxt += self.principal.read(1)
+
+            self.process_char(nxt.decode("utf8"))
         
         return result
 


### PR DESCRIPTION
Fixes the issue where the benchmark is outputting a special utf8 char that takes on more than one byte.

Before the fix:

```
lightning-gpus.0 [config.devices] [0]
lightning-gpus.0 [start] /home/delaunao/workspace/benchdevenv/env/bin/voir --config /opt/milabench/extra/lightning-gpus/voirconf-lightning-gpus.0-384a97a8bb2d5d89323fc897d5a5d82e.json /home/delaunao/workspace/benchdevenv/milabench/benchmarks/lightning/main.py --epochs 10 --num-workers 8 --loader pytorch --data /opt/milabench/data/FakeImageNet --model resnet152 --batch-size 256 [at 2025-12-05 20:50:50.747378]
lightning-gpus.0 [stderr] /home/delaunao/workspace/benchdevenv/env/lib/python3.12/site-packages/voir/cli.py:104: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
lightning-gpus.0 [stderr]   import pkg_resources
lightning-gpus.0 [stderr] Using bfloat16 Automatic Mixed Precision (AMP)
lightning-gpus.0 [stderr] GPU available: True (cuda), used: True
lightning-gpus.0 [stderr] TPU available: False, using: 0 TPU cores
lightning-gpus.0 [stderr] /home/delaunao/workspace/benchdevenv/env/lib/python3.12/site-packages/torch/cuda/__init__.py:435: UserWarning:
lightning-gpus.0 [stderr]     Found GPU0 NVIDIA GB10 which is of cuda capability 12.1.
lightning-gpus.0 [stderr]     Minimum and Maximum cuda capability supported by this version of PyTorch is
lightning-gpus.0 [stderr]     (8.0) - (12.0)
lightning-gpus.0 [stderr] 
lightning-gpus.0 [stderr]   queued_call()
lightning-gpus.0 [stderr] LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]
lightning-gpus.0 [stderr] /home/delaunao/workspace/benchdevenv/env/lib/python3.12/site-packages/lightning/pytorch/utilities/model_summary/model_summary.py:242: Precision bf16-mixed is not supported by the model summary.  Estimated model size in MB will not be accurate. Using 32 bits instead.
lightning-gpus.0 [stderr] Traceback (most recent call last):
lightning-gpus.0 [stderr] 
lightning-gpus.0 [stderr]   File "/home/delaunao/workspace/benchdevenv/milabench/milabench/commands/executors.py", line 39, in execute
lightning-gpus.0 [stderr]     return await run(
lightning-gpus.0 [stderr]            ^^^^^^^^^^
lightning-gpus.0 [stderr] 
lightning-gpus.0 [stderr]   File "/home/delaunao/workspace/benchdevenv/milabench/milabench/alt_async.py", line 162, in wrapped
lightning-gpus.0 [stderr]     while (x := next(g)) is not None:
lightning-gpus.0 [stderr]                 ^^^^^^^
lightning-gpus.0 [stderr] 
lightning-gpus.0 [stderr]   File "/home/delaunao/workspace/benchdevenv/milabench/milabench/alt_async.py", line 191, in run
lightning-gpus.0 [stderr]     for entry in mx:
lightning-gpus.0 [stderr] 
lightning-gpus.0 [stderr]   File "/home/delaunao/workspace/benchdevenv/env/lib/python3.12/site-packages/voir/proc.py", line 267, in __iter__
lightning-gpus.0 [stderr]     while line := r.readline():
lightning-gpus.0 [stderr]                   ^^^^^^^^^^^^
lightning-gpus.0 [stderr] 
lightning-gpus.0 [stderr]   File "/home/delaunao/workspace/benchdevenv/env/lib/python3.12/site-packages/voir/smuggle.py", line 188, in readline
lightning-gpus.0 [stderr]     return self.decoder.readline(self.which)
lightning-gpus.0 [stderr]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lightning-gpus.0 [stderr] 
lightning-gpus.0 [stderr]   File "/home/delaunao/workspace/benchdevenv/env/lib/python3.12/site-packages/voir/smuggle.py", line 164, in readline
lightning-gpus.0 [stderr]     self.process_char(nxt.decode("utf8"))
lightning-gpus.0 [stderr]                       ^^^^^^^^^^^^^^^^^^
lightning-gpus.0 [stderr] 
lightning-gpus.0 [stderr] UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe2 in position 0: unexpected end of data
lightning-gpus.0 [stderr] 
lightning-gpus.0 UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe2 in position 0: unexpected end of data: did you run milabench install/prepare?
```

After


```
lightning.D0 [start] /home/delaunao/workspace/benchdevenv/env/bin/voir --config /opt/milabench/extra/lightning/voirconf-lightning.D0-384a97a8bb2d5d89323fc897d5a5d82e.json /home/delaunao/workspace/benchdevenv/milabench/benchmarks/lightning/main.py --epochs 10 --num-workers 8 --loader pytorch --data /opt/milabench/data/FakeImageNet --model resnet152 --batch-size 256 [at 2025-12-08 17:51:43.166756]
lightning.D0 [stderr] /home/delaunao/workspace/benchdevenv/env/lib/python3.12/site-packages/voir/cli.py:104: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
lightning.D0 [stderr]   import pkg_resources
lightning.D0 [stderr] Using bfloat16 Automatic Mixed Precision (AMP)
lightning.D0 [stderr] GPU available: True (cuda), used: True
lightning.D0 [stderr] TPU available: False, using: 0 TPU cores
lightning.D0 [stderr] /home/delaunao/workspace/benchdevenv/env/lib/python3.12/site-packages/torch/cuda/__init__.py:435: UserWarning:
lightning.D0 [stderr]     Found GPU0 NVIDIA GB10 which is of cuda capability 12.1.
lightning.D0 [stderr]     Minimum and Maximum cuda capability supported by this version of PyTorch is
lightning.D0 [stderr]     (8.0) - (12.0)
lightning.D0 [stderr] 
lightning.D0 [stderr]   queued_call()
lightning.D0 [stderr] LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]
lightning.D0 [stderr] /home/delaunao/workspace/benchdevenv/env/lib/python3.12/site-packages/lightning/pytorch/utilities/model_summary/model_summary.py:242: Precision bf16-mixed is not supported by the model summary.  Estimated model size in MB will not be accurate. Using 32 bits instead.
lightning.D0 [stdout] ┏━━━┳━━━━━━━┳━━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━┓
lightning.D0 [stdout] ┃   ┃ Name  ┃ Type   ┃ Params ┃ Mode  ┃ FLOPs ┃
lightning.D0 [stdout] ┡━━━╇━━━━━━━╇━━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━┩
lightning.D0 [stdout] │ 0 │ model │ ResNet │ 60.2 M │ train │     0 │
lightning.D0 [stdout] └───┴───────┴────────┴────────┴───────┴───────┘
lightning.D0 [stdout] Trainable params: 60.2 M
lightning.D0 [stdout] Non-trainable params: 0
lightning.D0 [stdout] Total params: 60.2 M
lightning.D0 [stdout] Total estimated model params size (MB): 240
lightning.D0 [stdout] Modules in train mode: 423
lightning.D0 [stdout] Modules in eval mode: 0
lightning.D0 [stdout] Total FLOPs: 0
```