### PR TITLE
rocm: respect ROCM_PATH env var for rsmi path

### DIFF
--- a/src/voir/instruments/gpu/rocm.py
+++ b/src/voir/instruments/gpu/rocm.py
@@ -6,7 +6,7 @@ IMPORT_ERROR = None
 try:
     import sys
 
-    sys.path.append("/opt/rocm/libexec/rocm_smi/")
+    sys.path.append(os.path.join(os.environ.get("ROCM_PATH", "/opt/rocm"), "libexec/rocm_smi/"))
     import rsmiBindings as rsmi
 
 except ImportError as err:


### PR DESCRIPTION
Falls back to /opt/rocm when ROCM_PATH is unset, preserving existing behavior on standard installations.

  ## Summary

  On shared HPC clusters, ROCm is often installed at a non-standard path
  (e.g. `/shared/apps/ubuntu/opt/rocm-7.2.3/`) and creating a symlink at
  `/opt/rocm` is not always possible.

  This change makes the ROCm instrument respect the `ROCM_PATH` environment
  variable when locating the `rsmiBindings` library, falling back to `/opt/rocm`
  when it is unset — so existing standard installations are completely unaffected.

  - No new dependencies (`os` is already imported)
  - Fully backwards compatible
  - One-line change

  ## Test plan

  - [ ] Verify on a standard install (`ROCM_PATH` unset): rsmi loads from `/opt/rocm/libexec/rocm_smi/` as before
  - [ ] Verify with `ROCM_PATH=/path/to/rocm`: rsmi loads correctly from the custom path